### PR TITLE
jsqlparser4.9 sqlServer设置分页的时候，取别名需要换新写法

### DIFF
--- a/minidao-pe/src/main/java/org/jeecgframework/minidao/sqlparser/impl/util/v49/JSqlServerPagesHelper49.java
+++ b/minidao-pe/src/main/java/org/jeecgframework/minidao/sqlparser/impl/util/v49/JSqlServerPagesHelper49.java
@@ -263,25 +263,27 @@ public class JSqlServerPagesHelper49 {
         //设置selectItems
         List<SelectItem<?>> selectItems = new ArrayList<>();
         for (SelectItem<?> selectItem : plainSelect.getSelectItems()) {
-            Expression expression = selectItem.getExpression();
-            if (expression instanceof AllTableColumns) {
-                selectItems.add(new SelectItem<>(new AllColumns()));
-            } else if (expression instanceof Column) {
-                Column column = (Column) expression;
-                if (column.getTable() != null) {
-                    Column newColumn = new Column(column.getColumnName());
-                    selectItems.add(new SelectItem<>(newColumn));
-                } else {
-                    selectItems.add(selectItem);
-                }
-            }
-            //别名需要特殊处理
-            else if (selectItem.getAlias() != null) {
+            //update-begin---author:wangshuai---date:2025-06-05---for:【issues/3802】sprintboot3.3.6集成报表1.9.5，数据库是SQLserver。打开http://localhost:8080/jmreport/list报错，不能显示已有的报表---
+            if(selectItem.getAlias() != null){
                 //直接使用别名
                 Column column = new Column(selectItem.getAlias().getName());
                 selectItems.add(new SelectItem<>(column));
-            } else {
-                selectItems.add(selectItem);
+            }else {
+                Expression expression = selectItem.getExpression();
+                if (expression instanceof AllTableColumns) {
+                    selectItems.add(new SelectItem<>(new AllColumns()));
+                } else if (expression instanceof Column) {
+                    Column column = (Column) expression;
+                    if (column.getTable() != null) {
+                        Column newColumn = new Column(column.getColumnName());
+                        selectItems.add(new SelectItem<>(newColumn));
+                    } else {
+                        selectItems.add(selectItem);
+                    }
+                } else {
+                    selectItems.add(selectItem);
+                }
+                //update-end---author:wangshuai---date:2025-06-05---for:【issues/3802】sprintboot3.3.6集成报表1.9.5，数据库是SQLserver。打开http://localhost:8080/jmreport/list报错，不能显示已有的报表---
             }
         }
         // SELECT *, 1 AS alias FROM TEST


### PR DESCRIPTION
jsqlparser4.9 sqlServer设置分页的时候，取别名需要换新写法，解决对应bug ：【issues/3802】sprintboot3.3.6集成报表1.9.5，数据库是SQLserver。打开http://localhost:8080/jmreport/list报错，不能显示已有的报表